### PR TITLE
Make scripts save externally

### DIFF
--- a/xfl_parse/xml_node.gd
+++ b/xfl_parse/xml_node.gd
@@ -6,6 +6,7 @@ var children: Array[XMLNode]
 var parent: XMLNode = null
 var text: String = ""
 var c_data: String = ""
+var path: String = ""
 
 func _init(
 	p_name: String
@@ -15,6 +16,7 @@ func _init(
 
 func first_child_with_tag(tag: String) -> XMLNode:
 	for child in children:
+		child.path = path
 		if child.name == tag:
 			return child
 	return null
@@ -23,6 +25,7 @@ func first_child_with_tag(tag: String) -> XMLNode:
 func all_children_with_tag(tag: String) -> Array[XMLNode]:
 	var ret: Array[XMLNode] = []
 	for child in children:
+		child.path = path
 		if child.name == tag:
 			ret.append(child)
 	return ret
@@ -30,6 +33,7 @@ func all_children_with_tag(tag: String) -> Array[XMLNode]:
 
 func recurse_callback_with_tag(tag: String, callback: Callable):
 	for child in children:
+		child.path = path
 		if child.name == tag:
 			callback.call(child)
 		


### PR DESCRIPTION
Previously, scripts would be embedded in their relevant scenes. This separates them into their own files.

Problems:
- The method by which the file path to save a script to is not particularly intuitive, since it involves parent XMLNodes contaminating their children with the relevant path data any time they are accessed, rather than as a direct action. I would prefer a different solution, but none come to mind.
- The output directory is hardcoded, and does not follow the one set by the user.